### PR TITLE
Add a Dependency Between S3 Notification and Lambda Permission

### DIFF
--- a/notification-lambda.tf
+++ b/notification-lambda.tf
@@ -100,4 +100,5 @@ resource "aws_s3_bucket_notification" "lambda_bucket_notification" {
     lambda_function_arn = module.lambda_function.lambda_function_arn
     events              = ["s3:ObjectCreated:*"]
   }
+  depends_on = [aws_lambda_permission.allows_s3_to_call_cloudtrail_insight_lambda]
 }


### PR DESCRIPTION
There seems to be a race condition where the S3 bucket tries to configure the notification before the Lambda permissions are applied. 